### PR TITLE
Update clio.py

### DIFF
--- a/server/mhn/common/clio.py
+++ b/server/mhn/common/clio.py
@@ -217,7 +217,7 @@ class Session(ResourceMixin):
         intfields = ('destination_port', 'source_port',)
         for field in intfields:
             if field in clean:
-                clean = clean_integer(field, dirty)
+                clean = clean_integer(field, clean)
 
         if 'timestamp' in clean and isinstance(clean['timestamp'], basestring):
             # Transforms timestamp queries into


### PR DESCRIPTION
I am working on adding some additional filtering to the attacks page and noticed the _clean_query from Session() appear to undo all the work it did by passing the 'dirty' var (instead of the 'clean' var) into the _clean_integer function.
