### PR TITLE
Prevents dictionary changed size during iteration

### DIFF
--- a/server/mhn/common/clio.py
+++ b/server/mhn/common/clio.py
@@ -206,7 +206,7 @@ class Session(ResourceMixin):
             # If it's not a proper integer it will be remove
             # from the query.
             try:
-                integer = int(_query[field_name])
+                integer = int(query[field_name])
             except (ValueError, TypeError):
                 query.pop(field_name)
             else:


### PR DESCRIPTION
Let's not pass the same dict object to a function that will potentially remove items from it, inside a for loop that is iterating over it, which will raise: RuntimeError: dictionary changed size during iteration.
