### PR TITLE
Update deploy_snort.sh

### DIFF
--- a/scripts/deploy_snort.sh
+++ b/scripts/deploy_snort.sh
@@ -36,7 +36,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y snort
 sed -i 's,include \$RULE_PATH/community-sip.rules,#include \$RULE_PATH/community-sip.rules,1' /etc/snort/snort.conf
 
 # turn on 'full' snort alert logging
-sed -i 's/DEBIAN_SNORT_OPTIONS=.*/DEBIAN_SNORT_OPTIONS="-A full"/' /etc/snort/snort.debian.con
+sed -i 's/DEBIAN_SNORT_OPTIONS=.*/DEBIAN_SNORT_OPTIONS="-A full"/' /etc/snort/snort.debian.conf
 
 SNORT_HPF_HOME=/opt/snort_hpfeeds
 mkdir -p $SNORT_HPF_HOME


### PR DESCRIPTION
Fixed typo "snort.debian.conf" instead of "snort.debian.con"
