### PR TITLE
Fixing pagination when using custom limit.

### DIFF
--- a/server/mhn/common/utils.py
+++ b/server/mhn/common/utils.py
@@ -20,8 +20,9 @@ def alchemy_pages(query, **kwargs):
     return Pagination(page, page_size, query.count(), items)
 
 
-def mongo_pages(result, total):
-    return Pagination(g.page, PAGE_SIZE, total, result)
+def mongo_pages(result, total, **kwargs):
+    page_size = kwargs.get('limit', PAGE_SIZE)
+    return Pagination(g.page, page_size, total, result)
 
 
 def paginate_options(**kwargs):

--- a/server/mhn/ui/views.py
+++ b/server/mhn/ui/views.py
@@ -72,7 +72,7 @@ def get_attacks():
     total = clio.session.count(**request.args.to_dict())
     sessions = clio.session.get(
             options=options, **request.args.to_dict())
-    sessions = mongo_pages(sessions, total)
+    sessions = mongo_pages(sessions, total, limit=10)
     return render_template('ui/attacks.html', attacks=sessions,
                            sensors=Sensor.query, view='ui.get_attacks',
                            get_flag_ip=get_flag_ip, **request.args.to_dict())
@@ -106,7 +106,7 @@ def get_sensors():
     pag = paginate_options(limit=10)
     sensors = sensors[pag['skip']:pag['skip'] + pag['limit']]
     # Using mongo_pages because it expects paginated iterables.
-    sensors = mongo_pages(sensors, total)
+    sensors = mongo_pages(sensors, total, limit=10)
     return render_template('ui/sensors.html', sensors=sensors,
                            view='ui.get_sensors', pag=pag)
 


### PR DESCRIPTION
When specifying a custom limit to the `paginate_options` function, the
pagination object also needs to be constructed with this custom limit,
hence the added `kwargs` parameter to the `mongo_pages` function.

Closes #19, and probably #12.
