### PR TITLE
Update deploy_dionaea.sh to support trusty

### DIFF
--- a/scripts/deploy_dionaea.sh
+++ b/scripts/deploy_dionaea.sh
@@ -25,7 +25,7 @@ add-apt-repository -y ppa:honeynet/nightly
 apt-get update
 
 # Installing Dionaea.
-if [[ `lsb_release -cs` == "trusty"]]
+if [[ `lsb_release -cs` == "trusty" ]]
 	then
 		apt-get install -y dionaea-phibo supervisor patch
 	else


### PR DESCRIPTION
Added conditional statement to check if release is trusty and install dionaea-phibo instead of dionaea (dionaea unavailable for trusty in ppa:honeynet/nightly)

Alternately, you could change "apt-get install -y dionaea supervisor patch" to "apt-get install -y dionaea-phibo supervisor patch" as dionaea-phibo is also available for precise and builds from a newer git version.
