### PR TITLE
Add Secret field on add-sensor view

### DIFF
--- a/server/mhn/static/js/main.js
+++ b/server/mhn/static/js/main.js
@@ -33,6 +33,7 @@ $(document).ready(function() {
                 success: function(resp) {
                     $('#sensor-info').show();
                     $('#sensor-id').html('UUID: ' + resp.uuid);
+                    $('#sensor-secret').html('Secret: ' + resp.secret);
                 },
                 contentType: 'application/json',
                 error: function(resp) {

--- a/server/mhn/templates/ui/add-sensor.html
+++ b/server/mhn/templates/ui/add-sensor.html
@@ -45,6 +45,7 @@
         <div class="row">
             <div class="panel small-8 columns">
                 <h1><small id="sensor-id"></small></h1>
+                <h1><small id="sensor-secret"></small></h1>
             </div>
         </div>
     </div>


### PR DESCRIPTION
The process for adding a new external sensor was fairly complicated when it didn't have to be, really.
The add-sensor view made the same api-call that the registration script made, so the sensor was already registered. The ony problem was that we didn't have the secret, but that is very easy to add.

Now the process to add an external sensor is as simple as going to the add-sensor view, filling the form and then configuring the sensor with the values provided.