### PR TITLE
Add IP field to the Add a Sensor page

### DIFF
--- a/server/mhn/api/views.py
+++ b/server/mhn/api/views.py
@@ -35,7 +35,11 @@ def create_sensor():
     else:
         sensor = Sensor(**request.json)
         sensor.uuid = str(uuid1())
-        sensor.ip = request.remote_addr
+        try:
+            if request.json['ip'] == "":
+                sensor.ip = request.remote_addr
+        except KeyError:
+            sensor.ip = request.remote_addr
         Clio().authkey.new(**sensor.new_auth_dict()).post()
         try:
             db.session.add(sensor)

--- a/server/mhn/static/js/main.js
+++ b/server/mhn/static/js/main.js
@@ -21,7 +21,8 @@ $(document).ready(function() {
             var sensorObj = {
                 name: $('#name').val(),
                 hostname: $('#hostname').val(),
-                honeypot: $('#honeypot').val()
+                honeypot: $('#honeypot').val(),
+                ip: $('#ip').val()
             };
 
             $('#alert-row').hide();
@@ -385,7 +386,7 @@ $(document).ready(function() {
                         $('#error-txt').html(resp.responseJSON.error);
                         $('#msg-container').show();
                     }
-                });    
+                });
             } else {
                 $('#alert-text').removeClass('success').addClass('warning');
                 $('#error-txt').html('Not a valid email address');

--- a/server/mhn/templates/ui/add-sensor.html
+++ b/server/mhn/templates/ui/add-sensor.html
@@ -14,8 +14,11 @@
             <div class="small-3 columns">
                 <label>Hostname</label>
             </div>
-            <div class="small-3 pull-3 columns">
+            <div class="small-3 columns">
                 <label>Honeypot</label>
+            </div>
+	    <div class="small-3 columns">
+                <label>IP (optional)</label>
             </div>
         </div>
         <div class="row">
@@ -29,7 +32,10 @@
             <div class="small-3 columns">
                 <input id="honeypot" type="text" name="honeypot" />
             </div>
-            <div class="small-6 columns">
+	    <div class="small-3 columns">
+                <input id="ip" type="text" name="ip" />
+            </div>
+            <div class="small-3 columns">
                 <input id="create-btn" class="tiny button" type="submit" value="CREATE" />
             </div>
         </div>


### PR DESCRIPTION
I noticed that when adding a sensor using the web-ui, the sensors IP was always set to whatever IP the PC I was using had at the moment.
This only made sense to me in the case of adding a sensor from the sensor itself, and I don't know how common that use case is.

So anyways, I added an optional IP field to that page so that one can set the sensors IP when adding it. If no IP is supplied, the old behaviour takes over.

I tested:

- Adding a sensor WITH an IP from the webui
- Adding a sensor WITHOUT an IP from the webui
- Adding a sensor WITHOUT an IP using the registration.txt script

In all cases the result was as expected.