### PR TITLE
Added libssl-dev to conpot install script

### DIFF
--- a/scripts/deploy_conpot.sh
+++ b/scripts/deploy_conpot.sh
@@ -14,6 +14,8 @@ echo "deb http://en.archive.ubuntu.com/ubuntu precise main multiverse" | sudo te
 apt-get update
 apt-get install -y git libmysqlclient-dev libsmi2ldbl snmp-mibs-downloader python-dev libevent-dev libxslt1-dev libxml2-dev python-pip python-mysqldb pkg-config libvirt-dev supervisor
 apt-get install -y zlib1g-dev # needed for Ubuntu 14.04
+apt-get install libssl-dev -y # needed for Ubuntu 18.04 
+
 pip install --upgrade distribute
 pip install virtualenv
 


### PR DESCRIPTION
What: **Missing dlls**
Where: **deploy_conpot.sh**
Sensor Deployment OS: **Ubuntu 18.04**

**Error description**
I had the following install error when deploying conpot on Ubuntu 18.04 

`/usr/bin/ld: cannot find -lssl`
`/usr/bin/ld: cannot find -lcrypto`
`collect2: error: ld returned 1 exit status`
`error: command 'x86_64-linux-gnu-gcc' failed with exit status 1`

**The fix**
It turns out the ssl and crypto libs comes from the libssl-dev package. I added it to the install script and that fixed the error.

please note: I have not tested deploying on Ubuntu 14.04 and 16.04.