### PR TITLE
Updates ELK Install to use 7.x versions - Ref #740

### DIFF
--- a/scripts/install_elk.sh
+++ b/scripts/install_elk.sh
@@ -9,7 +9,7 @@ $DIR/install_hpfeeds-logger-json.sh
 ######
 ### Install ELK (https://www.elastic.co)
 #
-# Make sure the system has enought RAM (2GB was not enought for basic stuff), otherwise ES can suddently stop
+# Make sure the system has enought RAM (2GB was not enough for basic stuff), otherwise ES can suddently stop
 #
 ### ElasticSearch - https://www.elastic.co/guide/en/elasticsearch/reference/7.5/deb.html#deb-repo
 #
@@ -24,7 +24,7 @@ $DIR/install_hpfeeds-logger-json.sh
 #
 ### Logstash - https://www.elastic.co/guide/en/logstash/7.5/installing-logstash.html#_apt
 #
-# Runs on localhost:9600-9700. Config file /etc/logstash/logstash.yml & /etc/logstash/logstash.conf
+# Runs on localhost:9600-9700. Config file /etc/logstash/logstash.yml & /etc/logstash/conf.d/mhn.conf
 # Status: systemctl status logstash.service
 #
 ######
@@ -53,7 +53,6 @@ systemctl enable logstash.service
 systemctl start logstash.service
 
 cat > /etc/logstash/conf.d/mhn.conf <<EOF
-
 input {
   file {
     path => "/var/log/mhn/mhn-json.log"

--- a/scripts/install_elk.sh
+++ b/scripts/install_elk.sh
@@ -6,50 +6,53 @@ set -e
 DIR=`dirname "$0"`
 $DIR/install_hpfeeds-logger-json.sh
 
-# install Java
-apt-get install -y python-software-properties
-add-apt-repository -y ppa:webupd8team/java
-apt-get update
-apt-get -y install oracle-java8-installer
+######
+### Install ELK (https://www.elastic.co)
+#
+# Make sure the system has enought RAM (2GB was not enought for basic stuff), otherwise ES can suddently stop
+#
+### ElasticSearch - https://www.elastic.co/guide/en/elasticsearch/reference/7.5/deb.html#deb-repo
+#
+# Runs on localhost:9200. Config file: /etc/elasticsearch/elasticsearch.yml
+# Status: systemctl status elasticsearch.service
+# If exposed to the internet (not recommended), make sure to add FW rules to only allow trusted sources
+#
+### Kibana - https://www.elastic.co/guide/en/kibana/7.5/deb.html#deb-repo
+#
+# Runs on localhost:5601. Config file: /etc/kibana/kibana.yml
+# Status: systemctl status kibana.service
+#
+### Logstash - https://www.elastic.co/guide/en/logstash/7.5/installing-logstash.html#_apt
+#
+# Runs on localhost:9600-9700. Config file /etc/logstash/logstash.yml & /etc/logstash/logstash.conf
+# Status: systemctl status logstash.service
+#
+######
+
+# Install Java (required by ES)
+apt update
+apt install -y software-properties-common openjdk-8-jdk
 
 # Install ES
-wget -O - http://packages.elasticsearch.org/GPG-KEY-elasticsearch |  apt-key add -
-echo 'deb http://packages.elasticsearch.org/elasticsearch/1.4/debian stable main' |  tee /etc/apt/sources.list.d/elasticsearch.list
-apt-get update
-apt-get -y install elasticsearch=1.4.4
-sed -i '/network.host/c\network.host\:\ localhost' /etc/elasticsearch/elasticsearch.yml
-service elasticsearch restart
-update-rc.d elasticsearch defaults 95 10
+apt install -y apt-transport-https
+wget -qO - https://artifacts.elastic.co/GPG-KEY-elasticsearch | apt-key add -
+echo "deb https://artifacts.elastic.co/packages/7.x/apt stable main" | tee -a /etc/apt/sources.list.d/elastic-7.x.list
+apt update
+apt install -y elasticsearch
+systemctl enable elasticsearch.service
+systemctl start elasticsearch.service 
 
 # Install Kibana
-mkdir /tmp/kibana
-cd /tmp/kibana ;
-wget https://download.elasticsearch.org/kibana/kibana/kibana-4.0.1-linux-x64.tar.gz
-tar xvf kibana-4.0.1-linux-x64.tar.gz
-sed -i '/0.0.0.0/c\host\:\ localhost' /etc/elasticsearch/elasticsearch.yml
-mkdir -p /opt/kibana
-cp -R /tmp/kibana/kibana-4*/* /opt/kibana/
-rm -rf /tmp/kibana/kibana-4*
-
-cat > /etc/supervisor/conf.d/kibana.conf <<EOF
-[program:kibana]
-command=/opt/kibana/bin/kibana
-directory=/opt/kibana/
-stdout_logfile=/var/log/mhn/kibana.log
-stderr_logfile=/var/log/mhn/kibana.err
-autostart=true
-autorestart=true
-startsecs=10
-EOF
+apt install -y kibana
+systemctl enable kibana.service
+systemctl start kibana.service
 
 # Install Logstash
+apt install logstash
+systemctl enable logstash.service
+systemctl start logstash.service
 
-echo 'deb http://packages.elasticsearch.org/logstash/1.5/debian stable main' |  tee /etc/apt/sources.list.d/logstash.list
-apt-get update
-apt-get install logstash
-cd /opt/logstash
-
-cat > /opt/logstash/mhn.conf <<EOF
+cat > /etc/logstash/conf.d/mhn.conf <<EOF
 
 input {
   file {
@@ -64,11 +67,11 @@ filter {
   }
 
   geoip {
-      source => "src_ip"
-      target => "src_ip_geo"
-      database => "/opt/GeoLite2-City.mmdb"
-      add_field => [ "[src_ip_geo][coordinates]", "%{[src_ip_geo][longitude]}" ]
-      add_field => [ "[src_ip_geo][coordinates]", "%{[src_ip_geo][latitude]}"  ]
+    source => "src_ip"
+    target => "src_ip_geo"
+    database => "/opt/GeoLite2-City.mmdb"
+    add_field => [ "[src_ip_geo][coordinates]", "%{[src_ip_geo][longitude]}" ]
+    add_field => [ "[src_ip_geo][coordinates]", "%{[src_ip_geo][latitude]}"  ]
   }
   mutate {
     convert => [ "[src_ip_geo][coordinates]", "float"]
@@ -83,372 +86,272 @@ filter {
   }
 
   mutate {
-      convert => [ "[dst_ip_geo][coordinates]", "float"]
-    }
+    convert => [ "[dst_ip_geo][coordinates]", "float"]
+  }
 }
 
 output {
   elasticsearch {
-    host => "127.0.0.1"
-    port => 9200
-    protocol => "http"
+    hosts => ["http://localhost:9200"]
     index => "mhn-%{+YYYYMMddHH00}"
-    index_type => "event"
     template_name => "mhn_event"
-    template => "/opt/logstash/mhn-template.json"
+    template => "/etc/logstash/conf.d/mhn-template.json"
     template_overwrite => true
     manage_template => true
   }
 }
-
 EOF
 
-cat > /opt/logstash/mhn-template.json <<EOF
+cat > /etc/logstash/conf.d/mhn-template.json <<EOF
 {
-  "template": "mhn-*",
+  "index_patterns": "mhn-*",
   "settings": {
     "number_of_shards": 5,
     "number_of_replicas": 0,
     "refresh_interval": "30s"
   },
   "mappings": {
-    "_default_": {
-      "_source": {
-        "enabled": true
+    "properties": {
+      "app": {
+        "type": "keyword"
       },
-      "properties": {}
-    },
-    "event": {
-      "properties": {
-        "app": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "command": {
-          "type": "string",
-          "index": "analyzed"
-        },
-        "dest_area_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_city": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_country_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_country_code3": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_country_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_dma_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_ip": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_latitude": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_longitude": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_metro_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_org": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_port": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_postal_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_region": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_region_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dest_time_zone": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dionaea_action": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "direction": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "elastichoney_form": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "elastichoney_payload": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "eth_dst": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "eth_src": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ids_type": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ip_id": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ip_len": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ip_tos": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ip_ttl": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "md5": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "p0f_app": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "p0f_link": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "p0f_os": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "p0f_uptime": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "protocol": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "request_url": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "sensor": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "severity": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "sha512": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "signature": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_area_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_city": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_country_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_country_code3": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_country_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_dma_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_ip": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_latitude": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_longitude": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_metro_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_org": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_port": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_postal_code": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_region": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_region_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_time_zone": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ssh_password": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ssh_username": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "ssh_version": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "tcp_flags": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "tcp_len": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "transport": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "type": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "udp_len": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "url": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "user_agent": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "vendor_product": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_ip_geo.city_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_ip_geo.region_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_ip_geo.timezone": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_ip_geo.country_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "src_ip_geo"  : {
-          "type" : "object",
-          "dynamic": true,
-          "properties" : {
-            "location" : { "type" : "geo_point" }
-          }
-        },
-        "dst_ip_geo.city_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dst_ip_geo.region_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dst_ip_geo.timezone": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dst_ip_geo.country_name": {
-          "type": "string",
-          "index": "not_analyzed"
-        },
-        "dst_ip_geo"  : {
-          "type" : "object",
-          "dynamic": true,
-          "properties" : {
-            "location" : { "type" : "geo_point" }
-          }
+      "command": {
+        "type": "text"
+      },
+      "dest_area_code": {
+        "type": "keyword"
+      },
+      "dest_city": {
+        "type": "keyword"
+      },
+      "dest_country_code": {
+        "type": "keyword"
+      },
+      "dest_country_code3": {
+        "type": "keyword"
+      },
+      "dest_country_name": {
+        "type": "keyword"
+      },
+      "dest_dma_code": {
+        "type": "keyword"
+      },
+      "dest_ip": {
+        "type": "keyword"
+      },
+      "dest_latitude": {
+        "type": "keyword"
+      },
+      "dest_longitude": {
+        "type": "keyword"
+      },
+      "dest_metro_code": {
+        "type": "keyword"
+      },
+      "dest_org": {
+        "type": "keyword"
+      },
+      "dest_port": {
+        "type": "keyword"
+      },
+      "dest_postal_code": {
+        "type": "keyword"
+      },
+      "dest_region": {
+        "type": "keyword"
+      },
+      "dest_region_name": {
+        "type": "keyword"
+      },
+      "dest_time_zone": {
+        "type": "keyword"
+      },
+      "dionaea_action": {
+        "type": "keyword"
+      },
+      "direction": {
+        "type": "keyword"
+      },
+      "elastichoney_form": {
+        "type": "keyword"
+      },
+      "elastichoney_payload": {
+        "type": "keyword"
+      },
+      "eth_dst": {
+        "type": "keyword"
+      },
+      "eth_src": {
+        "type": "keyword"
+      },
+      "ids_type": {
+        "type": "keyword"
+      },
+      "ip_id": {
+        "type": "keyword"
+      },
+      "ip_len": {
+        "type": "keyword"
+      },
+      "ip_tos": {
+        "type": "keyword"
+      },
+      "ip_ttl": {
+        "type": "keyword"
+      },
+      "md5": {
+        "type": "keyword"
+      },
+      "p0f_app": {
+        "type": "keyword"
+      },
+      "p0f_link": {
+        "type": "keyword"
+      },
+      "p0f_os": {
+        "type": "keyword"
+      },
+      "p0f_uptime": {
+        "type": "keyword"
+      },
+      "protocol": {
+        "type": "keyword"
+      },
+      "request_url": {
+        "type": "keyword"
+      },
+      "sensor": {
+        "type": "keyword"
+      },
+      "severity": {
+        "type": "keyword"
+      },
+      "sha512": {
+        "type": "keyword"
+      },
+      "signature": {
+        "type": "keyword"
+      },
+      "src_area_code": {
+        "type": "keyword"
+      },
+      "src_city": {
+        "type": "keyword"
+      },
+      "src_country_code": {
+        "type": "keyword"
+      },
+      "src_country_code3": {
+        "type": "keyword"
+      },
+      "src_country_name": {
+        "type": "keyword"
+      },
+      "src_dma_code": {
+        "type": "keyword"
+      },
+      "src_ip": {
+        "type": "keyword"
+      },
+      "src_latitude": {
+        "type": "keyword"
+      },
+      "src_longitude": {
+        "type": "keyword"
+      },
+      "src_metro_code": {
+        "type": "keyword"
+      },
+      "src_org": {
+        "type": "keyword"
+      },
+      "src_port": {
+        "type": "keyword"
+      },
+      "src_postal_code": {
+        "type": "keyword"
+      },
+      "src_region": {
+        "type": "keyword"
+      },
+      "src_region_name": {
+        "type": "keyword"
+      },
+      "src_time_zone": {
+        "type": "keyword"
+      },
+      "ssh_password": {
+        "type": "keyword"
+      },
+      "ssh_username": {
+        "type": "keyword"
+      },
+      "ssh_version": {
+        "type": "keyword"
+      },
+      "tcp_flags": {
+        "type": "keyword"
+      },
+      "tcp_len": {
+        "type": "keyword"
+      },
+      "transport": {
+        "type": "keyword"
+      },
+      "type": {
+        "type": "keyword"
+      },
+      "udp_len": {
+        "type": "keyword"
+      },
+      "url": {
+        "type": "keyword"
+      },
+      "user_agent": {
+        "type": "keyword"
+      },
+      "vendor_product": {
+        "type": "keyword"
+      },
+      "src_ip_geo.city_name": {
+        "type": "keyword"
+      },
+      "src_ip_geo.region_name": {
+        "type": "keyword"
+      },
+      "src_ip_geo.timezone": {
+        "type": "keyword"
+      },
+      "src_ip_geo.country_name": {
+        "type": "keyword"
+      },
+      "src_ip_geo"  : {
+        "type" : "object",
+        "dynamic": true,
+        "properties" : {
+          "location" : { "type" : "geo_point" }
+        }
+      },
+      "dst_ip_geo.city_name": {
+        "type": "keyword"
+      },
+      "dst_ip_geo.region_name": {
+        "type": "keyword"
+      },
+      "dst_ip_geo.timezone": {
+        "type": "keyword"
+      },
+      "dst_ip_geo.country_name": {
+        "type": "keyword"
+      },
+      "dst_ip_geo"  : {
+        "type" : "object",
+        "dynamic": true,
+        "properties" : {
+          "location" : { "type" : "geo_point" }
         }
       }
     }
   }
 }
 EOF
-
-cat > /etc/supervisor/conf.d/logstash.conf <<EOF
-[program:logstash]
-command=/opt/logstash/bin/logstash -f mhn.conf
-directory=/opt/logstash/
-stdout_logfile=/var/log/mhn/logstash.log
-stderr_logfile=/var/log/mhn/logstash.err
-autostart=true
-autorestart=true
-startsecs=10
-EOF
-
-supervisorctl update

--- a/scripts/install_elk.sh
+++ b/scripts/install_elk.sh
@@ -21,6 +21,8 @@ $DIR/install_hpfeeds-logger-json.sh
 # If exposed to the internet (not recommended), make sure to add FW rules to only allow trusted sources
 #
 ### Kibana - https://www.elastic.co/guide/en/kibana/7.5/deb.html#deb-repo
+## https://www.elastic.co/guide/en/kibana/current/access.html
+## https://www.elastic.co/guide/en/kibana/current/kibana-authentication.html
 #
 # Runs on localhost:5601. Config file: /etc/kibana/kibana.yml
 # Status: sudo systemctl status kibana.service
@@ -262,3 +264,10 @@ cat > /etc/logstash/conf.d/mhn-template.json <<EOF
   }
 }
 EOF
+
+echo
+echo 'By default, ELK services listen on localhost. This could be troublesome if Kibana needs to be accessed on LAN or remotely.'
+echo 'To fix that, the server.host setting can be changed in /etc/kibana/kibana.yml.'
+echo 'However, please keep in mind that no authentication will be requested by default.'
+echo 'See https://www.elastic.co/guide/en/kibana/current/kibana-authentication.html to configure one.'
+echo


### PR DESCRIPTION
Script updated and working.

A few things:
- Make sure the system MHN is installed on has enough RAM and disk space. 3GB of RAM and 10GB of disk seem to be the minimum (tested with only one Sensor though). For instance, MHN installed on an Ubuntu server with only the basic (mail and SSH) along with ELK takes around 8.8GB of disk.
- I was unable to fix the following warnings in Logstash:
  - `Detected a 6.x and above cluster: the `type` event field won't be used to determine the document _type {:es_version=>7}`. Not sure where this type is taken from, maybe from the log.
  - `[org.logstash.instrument.metrics.gauge.LazyDelegatingGauge][main] A gauge metric of an unknown type (org.jruby.specialized.RubyArrayOneObject) has been create for key: cluster_uuids. This may result in invalid serialization. `
- It seems that HPFeeds (or something in between) restricts the data written in the `mhn-json.log` log which is then parsed by Logstash and fed to ES. For instance, even though the below was sent via hp_feeds
   ```json
  // I, [2020-01-05T14:39:45.802598 #81583]  INFO -- : publish to wordpot.events: 
  {  
    "source_ip":"192.168.1.42",
    "source_port":9292,
    "dest_ip":"192.168.1.42",
    "dest_port":"9292",
    "user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.14; rv:71.0) Gecko/20100101 Firefox/71.0",
    "url":"/wp-login.php",
    "request":{  
        "method":"POST",
        "path":"/wp-login.php",
        "query_string":{},
        "body":{  
            "log":"gwefery",
            "pwd":"gfurg",
            "wp-submit":"Log In",
            "redirect_to":"/wp-admin/",
            "testcookie":"1"
        },
        "referer":"http://192.168.1.42:9292/wp-login.php"
      }
  }
   ```
   the data in `mhn-json.log` was missing the request and user_agent data:
   ```json
  {  
    "direction":"inbound",
    "protocol":"ip",
    "ids_type":"network",
    "timestamp":"2020-01-05T13:39:45.943063",
    "vendor_product":"Wordpot",
    "type":"wordpot.alerts",
    "app":"wordpot",
    "src_ip":"192.168.1.42",
    "dest_port":"9292",
    "signature":"Wordpress Exploit, Scan, or Enumeration Attempted",
    "src_port":9292,
    "request_url":"/wp-login.php",
    "dest_ip":"192.168.1.42",
    "sensor":"0cad2d40-2fb8-11ea-8b4f-0800271514ba",
    "transport":"tcp",
    "severity":"high"
  }
   ```
   So if you have any idea how to be able to get the 'custom' data received by HPFeeds written in the log, please share