### PR TITLE
Fixed install_mhnserver.sh issue with url_encode import.

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,3 +1,4 @@
+Werkzeug==0.16.1
 argparse==1.2.1
 Flask==0.12.4
 Flask-Login==0.3.2


### PR DESCRIPTION
**What**: Broken dependency
**Where**: install_mhnserver.sh

**Error description**
running install_mhnserver.sh returnes an error:

+ python initdatabase.py
Traceback (most recent call last):
  File "initdatabase.py", line 1, in <module>
    from mhn import create_clean_db
  File "/opt/mhn/server/mhn/__init__.py", line 5, in <module>
    from flask_security import Security, SQLAlchemyUserDatastore
  File "/opt/mhn/env/local/lib/python2.7/site-packages/flask_security/__init__.py", line 13, in <module>
    from .core import Security, RoleMixin, UserMixin, AnonymousUser, current_user
  File "/opt/mhn/env/local/lib/python2.7/site-packages/flask_security/core.py", line 25, in <module>
    from .forms import LoginForm, ConfirmRegisterForm, RegisterForm, \
  File "/opt/mhn/env/local/lib/python2.7/site-packages/flask_security/forms.py", line 15, in <module>
    from flask_wtf import Form as BaseForm
  File "/opt/mhn/env/local/lib/python2.7/site-packages/flask_wtf/__init__.py", line 17, in <module>
    from .recaptcha import *
  File "/opt/mhn/env/local/lib/python2.7/site-packages/flask_wtf/recaptcha/__init__.py", line 2, in <module>
    from .fields import *
  File "/opt/mhn/env/local/lib/python2.7/site-packages/flask_wtf/recaptcha/fields.py", line 3, in <module>
    from . import widgets
  File "/opt/mhn/env/local/lib/python2.7/site-packages/flask_wtf/recaptcha/widgets.py", line 5, in <module>
    from werkzeug import url_encode
ImportError: cannot import name url_encode

**The fix**
Werkzeug library needed to be downgraded to 0.16.1 (it was updated to 1.0.0 couple hours ago and that caused the issue)