### PR TITLE
update index

### DIFF
--- a/scripts/deploy_cowrie.sh
+++ b/scripts/deploy_cowrie.sh
@@ -11,20 +11,19 @@ if [ $# -ne 2 ]
 fi
 
 apt-get update
-apt-get install -y python
+apt-get install -y python3
 
 server_url=$1
 deploy_key=$2
 
+apt-get install -y git python-virtualenv libssl-dev libffi-dev build-essential libpython3-dev python3-minimal authbind python3-venv python3-pip supervisor supervisor
 apt-get update
-apt-get -y install python-dev git supervisor authbind openssl python-virtualenv build-essential python-gmpy2 libgmp-dev libmpfr-dev libmpc-dev libssl-dev python-pip libffi-dev
 
-pip install -U supervisor
+pip3 install --upgrade pip
+
+pip3 install -U supervisor
 /etc/init.d/supervisor start || true
 
-sed -i 's/#Port/Port/g' /etc/ssh/sshd_config
-sed -i 's/Port 22$/Port 2222/g' /etc/ssh/sshd_config
-service ssh restart
 useradd -d /home/cowrie -s /bin/bash -m cowrie -g users
 
 cd /opt
@@ -36,40 +35,45 @@ git checkout 34f8464
 
 # Config for requirements.txt
 cat > /opt/cowrie/requirements.txt <<EOF
-twisted>=17.1.0
-cryptography>=2.1
-configparser
-pyopenssl
-pyparsing
-packaging
-appdirs>=1.4.0
-pyasn1_modules
-attrs
-service_identity
-python-dateutil
-tftpy
-bcrypt
+setuptools==44.0.0
+twisted==20.3.0
+cryptography==2.8
+configparser==4.0.2
+pyopenssl==19.1.0
+pyparsing==2.4.6
+packaging==20.3
+appdirs==1.4.3
+pyasn1_modules==0.2.8
+attrs==19.3.0
+service_identity==18.1.0
+python-dateutil==2.8.1
+tftpy==0.8.0
+bcrypt==3.1.7
+treq
 EOF
 
-virtualenv cowrie-env #env name has changed to cowrie-env on latest version of cowrie
+#virtualenv cowrie-env #env name has changed to cowrie-env on latest version of cowrie
+python3 -m venv cowrie-env
 source cowrie-env/bin/activate
 # without the following, i get this error:
 # Could not find a version that satisfies the requirement csirtgsdk (from -r requirements.txt (line 10)) (from versions: 0.0.0a5, 0.0.0a6, 0.0.0a5.linux-x86_64, 0.0.0a6.linux-x86_64, 0.0.0a3)
-pip install csirtgsdk==0.0.0a6
-pip install -r requirements.txt 
+pip3 install csirtgsdk==0.0.0a6
+pip3 install -r requirements.txt
+pip install hpfeeds==3.0.0
+pip install hpfeeds3==0.9.10
 
 # Register sensor with MHN server.
 wget $server_url/static/registration.txt -O registration.sh
 chmod 755 registration.sh
 # Note: this will export the HPF_* variables
-. ./registration.sh $server_url $deploy_key "cowrie"
+sudo ./registration.sh $server_url $deploy_key "cowrie"
 
 cd etc
 cp cowrie.cfg.dist cowrie.cfg
 sed -i 's/hostname = svr04/hostname = server/g' cowrie.cfg
 sed -i 's/listen_endpoints = tcp:2222:interface=0.0.0.0/listen_endpoints = tcp:22:interface=0.0.0.0/g' cowrie.cfg
 sed -i 's/version = SSH-2.0-OpenSSH_6.0p1 Debian-4+deb7u2/version = SSH-2.0-OpenSSH_6.7p1 Ubuntu-5ubuntu1.3/g' cowrie.cfg
-sed -i 's/#\[output_hpfeeds\]/[output_hpfeeds]/g' cowrie.cfg
+sed -i 's/#\[output_hpfeeds\]/[output_hpfeeds3]/g' cowrie.cfg
 sed -i '/\[output_hpfeeds\]/!b;n;cenabled = true' cowrie.cfg
 sed -i "s/#server = hpfeeds.mysite.org/server = $HPF_HOST/g" cowrie.cfg
 sed -i "s/#port = 10000/port = $HPF_PORT/g" cowrie.cfg
@@ -82,6 +86,9 @@ chown -R cowrie:users /opt/cowrie/
 touch /etc/authbind/byport/22
 chown cowrie /etc/authbind/byport/22
 chmod 770 /etc/authbind/byport/22
+
+# cowrie 34f8464 version error
+sed -i 's/output_hpfeeds/output_hpfeeds3/g' /opt/cowrie/src/cowrie/output/hpfeeds3.py
 
 # start.sh is deprecated on new Cowrie version and substituted by "bin/cowrie [start/stop/status]"
 sed -i 's/AUTHBIND_ENABLED=no/AUTHBIND_ENABLED=yes/' bin/cowrie
@@ -102,4 +109,3 @@ user=cowrie
 EOF
 
 supervisorctl update
-


### PR DESCRIPTION
change to use python3 install

this cowrie version look like to have some error with hpfeeds3.py

and I dont know why i can't catch the $HPF_xxx with registration.sh .... to auto fill script

so I change the cowrie config by my self like this

[output_hpfeeds3]
enabled = true
server = 
port = 10000
identifier = 
secret = 
debug=false

Im not sure this script can use your computer 
but its can help me to install cowrie and sent to my mongo use hpfeeds
