### PR TITLE
adds debian based kali linux mongo db support

### DIFF
--- a/scripts/install_mongo.sh
+++ b/scripts/install_mongo.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Install MongoDB for the appropriate OS and version.
-# Supports Ubuntu 14, 16, 18 and RHEL/CentOS 6.9
+# Supports Ubuntu 14, 16, 18, RHEL/CentOS 6.9 and kali linux 2020.2
 
 set -e
 set -x
@@ -14,6 +14,8 @@ if [ -f /etc/debian_version ]; then
         ./install_mongodb_ub16.sh
     elif [ "$(lsb_release -r -s)" == "18.04" ]; then
         ./install_mongodb_ub18.sh
+    elif [ "$(lsb_release -r -s)" == "2020.2" ]; then
+	    ./install_mongodb_debian.sh
     else
         echo -e "ERROR: Unknown OS\nExiting!"
         exit -1

--- a/scripts/install_mongodb_debian.sh
+++ b/scripts/install_mongodb_debian.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Install MongoDB for Debian kali linux 2020.2.
+
+set -e
+set -x
+
+sudo apt-get install gnupg
+
+wget -qO - https://www.mongodb.org/static/pgp/server-4.2.asc | sudo apt-key add -
+echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/debian buster/mongodb-org/4.2 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
+apt-get update
+apt-get install -y mongodb-org
+
+sed -i 's/127.0.0.1/0.0.0.0/g' /etc/mongod.conf
+
+cat > /etc/systemd/system/mongodb.service <<EOF
+[Unit]
+Description=High-performance, schema-free document-oriented database
+After=network.target
+
+[Service]
+User=mongodb
+ExecStart=/usr/bin/mongod --quiet --config /etc/mongod.conf
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+systemctl start mongodb
+systemctl status mongodb
+systemctl enable mongodb


### PR DESCRIPTION
While installing Modern Honeypot Network for Debian based Kali linux, the installation script throws error for installing MongoDB. This was because the $(lsb_release -r -s) gives "2020.2" for kali Linux and for Ubuntu the output is different. This addition makes the installation of MHN on Kali Linux really easy.