### PR TITLE
Ubuntu 14.04 mongo 3.6 update

### DIFF
--- a/scripts/install_mongodb_ub14.sh
+++ b/scripts/install_mongodb_ub14.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS  andn repo and MongoDB 3.4 going EOL in Jan 2020.
+# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS from the main repo, and MongoDB 3.4 going EOL in Jan 2020, and moving ot only 64-bit support.
 
 set -e
 set -x

--- a/scripts/install_mongodb_ub14.sh
+++ b/scripts/install_mongodb_ub14.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Installing MongoDB for Ubuntu 14.04 LTS.
+# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS  andn repo and MongoDB 3.4 going EOL in Jan 2020.
 
 set -e
 set -x
 
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
 apt-get update
 apt-get install -y mongodb-org
 sed -i 's/127.0.0.1/0.0.0.0/g' /etc/mongod.conf


### PR DESCRIPTION
Install was failing on Ubuntu 14.04 LTS due to changes in the MongoDB version EOL, distro support, and architecture support. This updates the install_mongodb_ub14.sh script to use MongoBD 3.6 amd64 packages.