### PR TITLE
Ubuntu 14.04 mongo 3.6 update and python six workaround

### DIFF
--- a/scripts/install_hpfeeds.sh
+++ b/scripts/install_hpfeeds.sh
@@ -13,7 +13,11 @@ if [ -f /etc/debian_version ]; then
 
     PYTHON=`which python`
     PIP=`which pip`
-    $PIP install virtualenv
+    if [ "$(lsb_release -r -s)" == "14.04" ]; then
+        $PIP install virtualenv --ignore-installed six
+    else
+        $PIP install virtualenv
+    fi
     VIRTUALENV=`which virtualenv`
 
 elif [ -f /etc/redhat-release ]; then

--- a/scripts/install_mongodb_ub14.sh
+++ b/scripts/install_mongodb_ub14.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS  andn repo and MongoDB 3.4 going EOL in Jan 2020.
+# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS from the main repo, and MongoDB 3.4 going EOL in Jan 2020, and moving ot only 64-bit support.
 
 set -e
 set -x

--- a/scripts/install_mongodb_ub14.sh
+++ b/scripts/install_mongodb_ub14.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS from the main repo, and MongoDB 3.4 going EOL in Jan 2020, and moving ot only 64-bit support.
+# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS from the main repo, MongoDB 3.4 going EOL in Jan 2020, and moving to only 64-bit support.
 
 set -e
 set -x

--- a/scripts/install_mongodb_ub14.sh
+++ b/scripts/install_mongodb_ub14.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
-# Installing MongoDB for Ubuntu 14.04 LTS.
+# Installing MongoDB 3.6 for Ubuntu 14.04 LTS. Updated due to MongoDB dropping Ubuntu 14.04 LTS  andn repo and MongoDB 3.4 going EOL in Jan 2020.
 
 set -e
 set -x
 
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10
-echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | tee /etc/apt/sources.list.d/mongodb.list
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2930ADAE8CAF5059EE73BB4B58712A2291FA4AD5
+echo "deb [ arch=amd64 ] https://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.6 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.6.list
 apt-get update
 apt-get install -y mongodb-org
 sed -i 's/127.0.0.1/0.0.0.0/g' /etc/mongod.conf


### PR DESCRIPTION
Installing on Ubuntu 14.04 LTS had been failing due to a conflict with the version of the preinstalled python six module and that Mongo has both dropped 14.04 LTS as an officially supported distro release and MongoDB 3.4 going EOL, as well as transitioning to 64-bit only releases. These patches update the installer to account for these.