### PR TITLE
make a change to a version of Flask-SQLAlchemy

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -4,7 +4,7 @@ Flask==0.12.4
 Flask-Login==0.3.2
 Flask-Mail==0.9.1
 Flask-Migrate==1.8.1
-Flask-SQLAlchemy==2.3.2
+Flask-SQLAlchemy==2.5.1
 Flask-Security==1.7.5
 Flask-Testing==0.7.1
 Flask-WTF==0.14.2


### PR DESCRIPTION
The current version of Flask-SQLAlchemy in server/requirements.txt is set to 2.3.2 but it will produce this error on a terminal due to its incompatibility: 

<img width="847" alt="image" src="https://user-images.githubusercontent.com/43360935/112125890-2273f980-8b81-11eb-9763-187d6585677c.png">

To fix this, its version should be changed to 2.5.1 according to the issue from flask-sqlalchemy's repo:
#https://github.com/pallets/flask-sqlalchemy/issues/910#issuecomment-802098285
