### PR TITLE
Updated Vagrantfile for windows/hyperv compatibility and future unattended deployment

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,10 +1,20 @@
 Vagrant.configure("2") do |config|
-  #config.vm.box = "ubuntu/trusty64"
-  config.vm.box = "ubuntu/xenial64"
-  #config.vm.box = "ubuntu/bionic64"
-  config.vm.provision :shell, path: "vagrant-bootstrap.sh"
-  config.vm.provider "virtualbox" do |v|
-    v.memory = 2048
-    v.cpus = 8
-  end
+	# If attempting unattended this will skip the request for SMB credentials
+	config.vm.synced_folder '.', '/vagrant', disabled: true
+	config.vm.define "server" do |server|
+		# These images are regularly updated and compatible
+		# with hyperv, parallels, virtualbox, and vmware_desktop
+		#server.vm.box = "bento/ubuntu-16.04"
+		server.vm.box = "bento/ubuntu-18.04"
+		#server.vm.box = "bento/centos-6"
+		server.vm.provider "hyperv" do |hv|
+			hv.memory = 4096
+			hv.cpus = 2
+		end
+		# If attempting unattended without SMB the repo needs
+		# to be downloaded
+		server.vm.provision :shell, inline: 'sudo git clone https://github.com/pwnlandia/mhn.git /opt/mhn/'
+		# Absolute path needs to be specified
+		server.vm.provision :shell, inline: 'sudo bash /opt/mhn/install.sh'
+	end
 end


### PR DESCRIPTION
Vagrant boxes have been updated to ones that are regularly updated.

I mentioned unattended because of the [scripts/install_mhnserver_unattended.sh](https://github.com/pwnlandia/mhn/blob/0abf0db9cd893c6d5c727d036e1f817c02de4c7b/scripts/install_mhnserver_unattended.sh) which I'm utilizing locally for more complete testing without user interaction.