### PR TITLE
Add token authentication to update sensor endpoint

### DIFF
--- a/server/mhn/api/views.py
+++ b/server/mhn/api/views.py
@@ -57,6 +57,7 @@ def get_sensors():
     return resp
 
 @api.route('/sensor/<uuid>/', methods=['PUT'])
+@token_auth
 @csrf.exempt
 def update_sensor(uuid):
     sensor = Sensor.query.filter_by(uuid=uuid).first_or_404()


### PR DESCRIPTION
Adds token authentication requirement for the update sensor endpoint to prevent unauthenticated modification of sensor name and hostname, as raised in #809 