### PR TITLE
Improve docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:18.04
 MAINTAINER threatstream
 
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections

--- a/scripts/docker_expect.sh
+++ b/scripts/docker_expect.sh
@@ -33,4 +33,6 @@ expect "Would you like to integrate with Splunk?"
 send "n\r"
 expect "Would you like to install ELK?"
 send "n\r"
+expect "Would you like to add MHN rules to UFW?"
+send "n\r"
 expect EOF


### PR DESCRIPTION
- Currently MHN does not work with ubuntu 20.04. Docker image changed from latest to 18.04. 

-  Docker installation does not complete because there is no answer in docker_expect.sh file for UFW configuration. Proper expect statement added.