### PR TITLE
Remove max open files increase

### DIFF
--- a/scripts/deploy_amun.sh
+++ b/scripts/deploy_amun.sh
@@ -27,11 +27,6 @@ sed -i 's/ip: 127.0.0.1/ip: 0.0.0.0/g' conf/amun.conf
 sed -i 's/    vuln-http,/#   vuln-http,/g' conf/amun.conf
 sed -i $'s/log_modules:/log_modules:\\\n    log-hpfeeds/g' conf/amun.conf
 
-# Modify Ubuntu to accept more open files
-echo "104854" > /proc/sys/fs/file-max
-ulimit -Hn 104854
-ulimit -n 104854
-
 # Register the sensor with the MHN server.
 wget $server_url/static/registration.txt -O registration.sh
 chmod 755 registration.sh


### PR DESCRIPTION
An attempted increase the the max number of open files for all Linux systems is causing the deployment to fail. My testing shows that `9223372036854775807` is the current default amount.